### PR TITLE
Inner loop Matrix performance fix for TopicModel

### DIFF
--- a/core/src/main/java/org/apache/mahout/clustering/lda/cvb/TopicModel.java
+++ b/core/src/main/java/org/apache/mahout/clustering/lda/cvb/TopicModel.java
@@ -309,7 +309,11 @@ public class TopicModel implements Configurable, Iterable<MatrixSlice> {
   }
 
   public void updateTopic(int topic, Vector docTopicCounts) {
-    topicTermCounts.viewRow(topic).assign(docTopicCounts, Functions.PLUS);
+    Iterator<Vector.Element> it = docTopicCounts.iterateNonZero();
+    while(it.hasNext()) {
+      Vector.Element e = it.next();
+      topicTermCounts.set(topic, e.index(), topicTermCounts.get(topic, e.index()) + e.get());
+    }
     topicSums.set(topic, topicSums.get(topic) + docTopicCounts.norm(1));
   }
 

--- a/core/src/main/java/org/apache/mahout/clustering/lda/cvb/TopicModel.java
+++ b/core/src/main/java/org/apache/mahout/clustering/lda/cvb/TopicModel.java
@@ -266,7 +266,7 @@ public class TopicModel implements Configurable, Iterable<MatrixSlice> {
     // first calculate p(topic|term,document) for all terms in original, and all topics,
     // using p(term|topic) and p(topic|doc)
     pTopicGivenTerm(original, topics, docTopicModel);
-    normalizeByTopic(docTopicModel);
+    normalizeByTopic(original, docTopicModel);
     // now multiply, term-by-term, by the document, to get the weighted distribution of
     // term-topic pairs from this document.
     Iterator<Vector.Element> it = original.iterateNonZero();
@@ -390,19 +390,23 @@ public class TopicModel implements Configurable, Iterable<MatrixSlice> {
     return -perplexity;
   }
 
-  private void normalizeByTopic(Matrix perTopicSparseDistributions) {
-    Iterator<Vector.Element> it = perTopicSparseDistributions.viewRow(0).iterateNonZero();
+  /**
+   *
+   * @param doc just here to provide a sparse iterator
+   * @param perTopicSparseDistributions
+   */
+  private void normalizeByTopic(Vector doc, Matrix perTopicSparseDistributions) {
+    Iterator<Vector.Element> it = doc.iterateNonZero();
     // then make sure that each of these is properly normalized by topic: sum_x(p(x|t,d)) = 1
     while(it.hasNext()) {
       Vector.Element e = it.next();
       int a = e.index();
       double sum = 0;
       for(int x = 0; x < numTopics; x++) {
-        sum += perTopicSparseDistributions.viewRow(x).get(a);
+        sum += perTopicSparseDistributions.get(x, a);
       }
       for(int x = 0; x < numTopics; x++) {
-        perTopicSparseDistributions.viewRow(x).set(a,
-            perTopicSparseDistributions.viewRow(x).get(a) / sum);
+        perTopicSparseDistributions.set(x, a, perTopicSparseDistributions.get(x, a) / sum);
       }
     }
   }

--- a/core/src/main/java/org/apache/mahout/clustering/lda/cvb/TopicModel.java
+++ b/core/src/main/java/org/apache/mahout/clustering/lda/cvb/TopicModel.java
@@ -280,7 +280,12 @@ public class TopicModel implements Configurable, Iterable<MatrixSlice> {
     // now recalculate p(topic|doc) by summing contributions from all of pTopicGivenTerm
     topics.assign(0.0);
     for(int x = 0; x < numTopics; x++) {
-      topics.set(x, docTopicModel.viewRow(x).norm(1));
+      it = original.iterateNonZero();
+      double norm = 0;
+      while(it.hasNext() && (e = it.next())!= null && e.index() < numTerms) {
+        norm += docTopicModel.get(x, e.index());
+      }
+      topics.set(x, norm);
     }
     // now renormalize so that sum_x(p(x|doc)) = 1
     topics.assign(Functions.mult(1/topics.norm(1)));


### PR DESCRIPTION
Avoid super-slow inner loop dense vector iteration by unrolling and manually iterating.
