### PR TITLE
Adds Eclipse M2E plugin configuration to avoid build errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -589,6 +589,50 @@
             </supplementalModels>
           </configuration>
         </plugin>
+
+        <!-- This plugin's configuration is used to store Eclipse M2E plugin
+             settings only. It has no influence on the Maven build itself. The
+             configuration below is required to resolve build errors reported by
+             M2E plugin. -->
+
+        <plugin>
+          <groupId>org.eclipse.m2e</groupId>
+          <artifactId>lifecycle-mapping</artifactId>
+          <version>1.0.0</version>
+          <configuration>
+            <lifecycleMappingMetadata>
+              <pluginExecutions>
+                <pluginExecution>
+                  <pluginExecutionFilter>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-antrun-plugin</artifactId>
+                    <versionRange>[1.6,)</versionRange>
+                    <goals>
+                      <goal>run</goal>
+                    </goals>
+                  </pluginExecutionFilter>
+                  <action>
+                    <ignore />
+                  </action>
+                </pluginExecution>
+                <pluginExecution>
+                  <pluginExecutionFilter>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-dependency-plugin</artifactId>
+                    <versionRange>[1.0.0,)</versionRange>
+                    <goals>
+                      <goal>copy-dependencies</goal>
+                    </goals>
+                  </pluginExecutionFilter>
+                  <action>
+                    <ignore />
+                  </action>
+                </pluginExecution>
+              </pluginExecutions>
+            </lifecycleMappingMetadata>
+          </configuration>
+        </plugin>
+
       </plugins>
     </pluginManagement>
     <plugins>


### PR DESCRIPTION
The Eclipse M2E plugin recently changed the way it handles evaluation of Maven plugins tied to specific build lifecycle stages. Unfortunately, its configuration has become more complex and now requires the included pom configuration to avoid build errors within Eclipse. This change does not affect the mvn build outside Eclipse.
