### PR TITLE
Adds TopicModel.infer methods

### DIFF
--- a/core/src/main/java/org/apache/mahout/clustering/lda/cvb/CVB0DocInferenceMapper.java
+++ b/core/src/main/java/org/apache/mahout/clustering/lda/cvb/CVB0DocInferenceMapper.java
@@ -16,28 +16,30 @@
  */
 package org.apache.mahout.clustering.lda.cvb;
 
+import java.io.IOException;
+
 import org.apache.hadoop.io.IntWritable;
-import org.apache.mahout.math.DenseVector;
-import org.apache.mahout.math.Matrix;
-import org.apache.mahout.math.SparseRowMatrix;
 import org.apache.mahout.math.Vector;
 import org.apache.mahout.math.VectorWritable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
-
 public class CVB0DocInferenceMapper extends CachingCVB0Mapper {
   private static final Logger log = LoggerFactory.getLogger(CVB0DocInferenceMapper.class);
+  private double minRelPerplexityDiff;
+  private int maxIterations;
+
+  @Override
+  protected void setup(Context context) throws IOException, InterruptedException {
+    super.setup(context);
+    minRelPerplexityDiff = config.getMinRelPreplexityDiff();
+    maxIterations = config.getMaxInferenceItersPerDoc();
+  }
 
   @Override
   public void map(IntWritable docId, VectorWritable doc, Context context)
       throws IOException, InterruptedException {
-    Vector docTopics = new DenseVector(new double[numTopics]).assign(1.0 / numTopics);
-    Matrix docModel = new SparseRowMatrix(numTopics, doc.get().size());
-    for(int i = 0; i < maxIters; i++) {
-      modelTrainer.getReadModel().trainDocTopicModel(doc.get(), docTopics, docModel);
-    }
+    Vector docTopics = modelTrainer.getReadModel().infer(doc.get(), minRelPerplexityDiff, maxIterations);
     context.write(docId, new VectorWritable(docTopics));
   }
 

--- a/core/src/main/java/org/apache/mahout/clustering/lda/cvb/CVB0Driver.java
+++ b/core/src/main/java/org/apache/mahout/clustering/lda/cvb/CVB0Driver.java
@@ -149,6 +149,7 @@ public class CVB0Driver extends AbstractJob {
     addOption(CVBConfig.PERSIST_INTERMEDIATE_DOCTOPICS_PARAM, "pidt", "persist and update intermediate p(topic|doc)", "false");
     addOption(CVBConfig.DOC_TOPIC_PRIOR_PATH_PARAM, "dtp", "path to prior values of p(topic|doc) matrix");
     addOption(CVBConfig.MAX_ITERATIONS_PER_DOC_PARAM, "mipd", "max number of iterations per doc for p(topic|doc) learning", String.valueOf(CVBConfig.MAX_ITERATIONS_PER_DOC_DEFAULT));
+    addOption(CVBConfig.MAX_INFERENCE_ITERATIONS_PER_DOC_PARAM, "int", "max number of iterations per doc for p(topic|doc) inference", String.valueOf(CVBConfig.MAX_INFERENCE_ITERATIONS_PER_DOC_DEFAULT));
     addOption(CVBConfig.NUM_REDUCE_TASKS_PARAM, null, "number of reducers to use during model estimation", String.valueOf(CVBConfig.NUM_REDUCE_TASKS_DEFAULT));
     addOption(CVBConfig.ONLY_LABELED_DOCS_PARAM, "ol", "only use docs with non-null doc/topic priors", "false");
     addOption(buildOption(CVBConfig.BACKFILL_PERPLEXITY_PARAM, null, "enable back-filling of missing perplexity values", false, false, null));
@@ -168,6 +169,7 @@ public class CVB0Driver extends AbstractJob {
     int numTrainThreads = Integer.parseInt(getOption(CVBConfig.NUM_TRAIN_THREADS_PARAM));
     int numUpdateThreads = Integer.parseInt(getOption(CVBConfig.NUM_UPDATE_THREADS_PARAM));
     int maxItersPerDoc = Integer.parseInt(getOption(CVBConfig.MAX_ITERATIONS_PER_DOC_PARAM));
+    int maxInferenceItersPerDoc = Integer.parseInt(getOption(CVBConfig.MAX_INFERENCE_ITERATIONS_PER_DOC_PARAM));
     Path dictionaryPath = hasOption(CVBConfig.DICTIONARY_PATH_PARAM) ? new Path(getOption(CVBConfig.DICTIONARY_PATH_PARAM)) : null;
     int numTerms = hasOption(CVBConfig.NUM_TERMS_PARAM)
                  ? Integer.parseInt(getOption(CVBConfig.NUM_TERMS_PARAM))
@@ -196,6 +198,7 @@ public class CVB0Driver extends AbstractJob {
         .setPersistDocTopics(persistDocTopics)
         .setIterationBlockSize(iterationBlockSize).setMaxIterations(maxIterations)
         .setMaxItersPerDoc(maxItersPerDoc).setModelTempPath(modelTempPath)
+        .setMaxInferenceItersPerDoc(maxInferenceItersPerDoc)
         .setNumReduceTasks(numReduceTasks).setNumTrainThreads(numTrainThreads)
         .setNumUpdateThreads(numUpdateThreads).setNumTerms(numTerms).setNumTopics(numTopics)
         .setTestFraction(testFraction).setRandomSeed(seed).setUseOnlyLabeledDocs(useOnlyLabeledDocs);
@@ -667,7 +670,7 @@ public class CVB0Driver extends AbstractJob {
 
   public static final class Id implements
       org.apache.hadoop.mapred.Mapper<IntWritable, VectorWritable, IntWritable, VectorWritable> {
-    
+
     @Override public void map(IntWritable k, VectorWritable v,
         OutputCollector<IntWritable, VectorWritable> out, Reporter reporter) throws IOException {
       out.collect(k, v);

--- a/core/src/main/java/org/apache/mahout/clustering/lda/cvb/CVBConfig.java
+++ b/core/src/main/java/org/apache/mahout/clustering/lda/cvb/CVBConfig.java
@@ -16,26 +16,30 @@
  */
 package org.apache.mahout.clustering.lda.cvb;
 
-import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Maps;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.mahout.common.commandline.DefaultOptionCreator;
 
-import java.util.Map;
+import com.google.common.base.Preconditions;
 
+/**
+ * CVB Configuration utilities. This class encapsulates all parameters required to invoke
+ * {@link CVB0Driver}. Parameter names and default values are also defined here.
+ */
 public class CVBConfig {
   // parameter names
+  public static final String INPUT_PATH_PARAM = DefaultOptionCreator.INPUT_OPTION;
+  public static final String DICTIONARY_PATH_PARAM = "dictionary";
+  public static final String DOC_TOPIC_PRIOR_PATH_PARAM = "doc_topic_prior_path";
+  public static final String MODEL_TEMP_PATH_PARAM = "topic_model_temp_dir";
+  public static final String OUTPUT_PATH_PARAM = DefaultOptionCreator.OUTPUT_OPTION;
+  public static final String DOC_TOPIC_OUTPUT_PATH_PARAM = "doc_topic_output";
   public static final String NUM_TOPICS_PARAM = "num_topics";
   public static final String NUM_TERMS_PARAM = "num_terms";
   public static final String DOC_TOPIC_SMOOTHING_PARAM = "doc_topic_smoothing";
   public static final String TERM_TOPIC_SMOOTHING_PARAM = "term_topic_smoothing";
   public static final String MAX_ITERATIONS_PARAM = DefaultOptionCreator.MAX_ITERATIONS_OPTION;
   public static final String CONVERGENCE_DELTA_PARAM = DefaultOptionCreator.CONVERGENCE_DELTA_OPTION;
-  public static final String DICTIONARY_PARAM = "dictionary";
-  public static final String DOC_TOPIC_OUTPUT_PARAM = "doc_topic_output";
-  public static final String MODEL_TEMP_DIR_PARAM = "topic_model_temp_dir";
   public static final String ITERATION_BLOCK_SIZE_PARAM = "iteration_block_size";
   public static final String RANDOM_SEED_PARAM = "random_seed";
   public static final String TEST_SET_FRACTION_PARAM = "test_set_fraction";
@@ -45,15 +49,16 @@ public class CVBConfig {
   public static final String MODEL_WEIGHT_PARAM = "prev_iter_mult";
   public static final String NUM_REDUCE_TASKS_PARAM = "num_reduce_tasks";
   public static final String PERSIST_INTERMEDIATE_DOCTOPICS_PARAM = "persist_intermediate_doctopics";
-  public static final String DOC_TOPIC_PRIOR_PARAM = "doc_topic_prior_path";
   public static final String BACKFILL_PERPLEXITY_PARAM = "backfill_perplexity";
   public static final String ONLY_LABELED_DOCS_PARAM = "labeled_only";
+  public static final String MIN_RELATIVE_PERPLEXITY_DIFF_PARAM = "min_rel_perplexity_diff";
+  public static final String MAX_INFERENCE_ITERATIONS_PER_DOC_PARAM = "max_inf_doc_topic_iters";
 
   // default values
   public static final float DOC_TOPIC_SMOOTHING_DEFAULT = 1e-5f;
   public static final float TERM_TOPIC_SMOOTHING_DEFAULT = 1e-5f;
   public static final int MAX_ITERATIONS_DEFAULT = 30;
-  public static final int ITERATION_BLOCK_SIZE_DEFAULT = 1;
+  public static final int ITERATION_BLOCK_SIZE_DEFAULT = 5;
   public static final float CONVERGENCE_DELTA_DEFAULT = 1e-5f;
   public static final long RANDOM_SEED_DEFAULT = 1234l;
   public static final float TEST_SET_FRACTION_DEFAULT = 1e-2f;
@@ -62,10 +67,16 @@ public class CVBConfig {
   public static final int MAX_ITERATIONS_PER_DOC_DEFAULT = 10;
   public static final int NUM_REDUCE_TASKS_DEFAULT = 1;
   public static final float MODEL_WEIGHT_DEFAULT = 1f;
-  
+  public static final float MIN_RELATIVE_PERPLEXITY_DIFF_DEFAULT = 1e-8f;
+  public static final int MAX_INFERENCE_ITERATIONS_PER_DOC_DEFAULT = 100;
+
   // TODO: sensible defaults and/or checks for validity
   private Path inputPath;
+  private Path dictionaryPath;
+  private Path docTopicPriorPath;
+  private Path modelTempPath;
   private Path outputPath;
+  private Path docTopicOutputPath;
   private int numTopics;
   private int numTerms;
   private float alpha = DOC_TOPIC_SMOOTHING_DEFAULT;
@@ -73,10 +84,6 @@ public class CVBConfig {
   private int maxIterations = MAX_ITERATIONS_DEFAULT;
   private int iterationBlockSize = ITERATION_BLOCK_SIZE_DEFAULT;
   private float convergenceDelta = CONVERGENCE_DELTA_DEFAULT;
-  private Path dictionaryPath;
-  private Path docTopicOutputPath;
-  private Path modelTempPath;
-  private Path docTopicPriorPath;
   private boolean persistDocTopics;
   private long randomSeed = RANDOM_SEED_DEFAULT;
   private float testFraction = TEST_SET_FRACTION_DEFAULT;
@@ -87,6 +94,8 @@ public class CVBConfig {
   private boolean backfillPerplexity;
   private boolean useOnlyLabeledDocs;
   private float modelWeight = MODEL_WEIGHT_DEFAULT;
+  private float minRelPreplexityDiff = MIN_RELATIVE_PERPLEXITY_DIFF_DEFAULT;
+  private int maxInferenceItersPerDoc = MAX_INFERENCE_ITERATIONS_PER_DOC_DEFAULT;
 
   public boolean isUseOnlyLabeledDocs() {
     return useOnlyLabeledDocs;
@@ -106,12 +115,54 @@ public class CVBConfig {
     return this;
   }
 
+  public Path getDictionaryPath() {
+    return dictionaryPath;
+  }
+
+  public CVBConfig setDictionaryPath(Path dictionaryPath) {
+    this.dictionaryPath = dictionaryPath;
+    return this;
+  }
+
+  public Path getDocTopicPriorPath() {
+    return docTopicPriorPath;
+  }
+
+  public CVBConfig setDocTopicPriorPath(Path docTopicPriorPath) {
+    this.docTopicPriorPath = docTopicPriorPath;
+    return this;
+  }
+
+  public Path getModelTempPath() {
+    return modelTempPath;
+  }
+
+  public CVBConfig setModelTempPath(Path modelTempPath) {
+    this.modelTempPath = modelTempPath;
+    return this;
+  }
+
   public Path getOutputPath() {
     return outputPath;
   }
 
   public CVBConfig setOutputPath(Path outputPath) {
     this.outputPath = outputPath;
+    return this;
+  }
+
+  public Path getDocTopicOutputPath() {
+    return docTopicOutputPath;
+  }
+
+  /**
+   * @param docTopicOutputPath path for doc-topic distributions. If set, once the model is trained a
+   * final inference job will be executed to produce p(topic|doc) estimates for input documents.
+   * Defaults to {@code null}.
+   * @return this.
+   */
+  public CVBConfig setDocTopicOutputPath(Path docTopicOutputPath) {
+    this.docTopicOutputPath = docTopicOutputPath;
     return this;
   }
 
@@ -175,42 +226,6 @@ public class CVBConfig {
 
   public CVBConfig setConvergenceDelta(float convergenceDelta) {
     this.convergenceDelta = convergenceDelta;
-    return this;
-  }
-
-  public Path getDictionaryPath() {
-    return dictionaryPath;
-  }
-
-  public CVBConfig setDictionaryPath(Path dictionaryPath) {
-    this.dictionaryPath = dictionaryPath;
-    return this;
-  }
-
-  public Path getDocTopicOutputPath() {
-    return docTopicOutputPath;
-  }
-
-  public CVBConfig setDocTopicOutputPath(Path docTopicOutputPath) {
-    this.docTopicOutputPath = docTopicOutputPath;
-    return this;
-  }
-
-  public Path getModelTempPath() {
-    return modelTempPath;
-  }
-
-  public CVBConfig setModelTempPath(Path modelTempPath) {
-    this.modelTempPath = modelTempPath;
-    return this;
-  }
-
-  public Path getDocTopicPriorPath() {
-    return docTopicPriorPath;
-  }
-
-  public CVBConfig setDocTopicPriorPath(Path docTopicPriorPath) {
-    this.docTopicPriorPath = docTopicPriorPath;
     return this;
   }
 
@@ -294,7 +309,25 @@ public class CVBConfig {
     this.modelWeight = modelWeight;
     return this;
   }
-  
+
+  public float getMinRelPreplexityDiff() {
+    return minRelPreplexityDiff;
+  }
+
+  public CVBConfig setMinRelPreplexityDiff(float minRelPreplexityDiff) {
+    this.minRelPreplexityDiff = minRelPreplexityDiff;
+    return this;
+  }
+
+  public int getMaxInferenceItersPerDoc() {
+    return maxInferenceItersPerDoc;
+  }
+
+  public CVBConfig setMaxInferenceItersPerDoc(int maxInferenceItersPerDoc) {
+    this.maxInferenceItersPerDoc = maxInferenceItersPerDoc;
+    return this;
+  }
+
   public void write(Configuration conf) {
     conf.setInt(NUM_TOPICS_PARAM, numTopics);
     conf.setInt(NUM_TERMS_PARAM, numTerms);
@@ -307,6 +340,8 @@ public class CVBConfig {
     conf.setInt(MAX_ITERATIONS_PER_DOC_PARAM, maxItersPerDoc);
     conf.setFloat(MODEL_WEIGHT_PARAM, modelWeight);
     conf.setBoolean(ONLY_LABELED_DOCS_PARAM, useOnlyLabeledDocs);
+    conf.setFloat(MIN_RELATIVE_PERPLEXITY_DIFF_PARAM, minRelPreplexityDiff);
+    conf.setInt(MAX_INFERENCE_ITERATIONS_PER_DOC_PARAM, maxInferenceItersPerDoc);
   }
 
   public CVBConfig read(Configuration conf) {
@@ -321,10 +356,12 @@ public class CVBConfig {
     setMaxItersPerDoc(conf.getInt(MAX_ITERATIONS_PER_DOC_PARAM, 0));
     setModelWeight(conf.getFloat(MODEL_WEIGHT_PARAM, 0));
     setUseOnlyLabeledDocs(conf.getBoolean(ONLY_LABELED_DOCS_PARAM, false));
+    setMinRelPreplexityDiff(conf.getFloat(MIN_RELATIVE_PERPLEXITY_DIFF_PARAM, -1));
+    setMaxInferenceItersPerDoc(conf.getInt(MAX_INFERENCE_ITERATIONS_PER_DOC_PARAM, 0));
     check();
     return this;
   }
-  
+
   public void check() {
     checkPositive(NUM_TOPICS_PARAM, numTopics);
     checkPositive(NUM_TERMS_PARAM, numTerms);
@@ -336,8 +373,10 @@ public class CVBConfig {
     checkPositive(NUM_UPDATE_THREADS_PARAM, numUpdateThreads);
     checkPositive(MAX_ITERATIONS_PER_DOC_PARAM, maxItersPerDoc);
     checkGreaterOrEqual(MODEL_WEIGHT_PARAM, modelWeight, 1);
+    checkGreaterOrEqual(MIN_RELATIVE_PERPLEXITY_DIFF_PARAM, minRelPreplexityDiff, 0);
+    checkPositive(MAX_INFERENCE_ITERATIONS_PER_DOC_PARAM, maxInferenceItersPerDoc);
   }
-  
+
   protected void checkGreater(String param, Number value, Number threshold) {
     Preconditions.checkArgument(value.doubleValue() > threshold.doubleValue(), "Expecting %s > %d but found %s", param, threshold, value);
   }
@@ -345,7 +384,7 @@ public class CVBConfig {
   protected void checkGreaterOrEqual(String param, Number value, Number threshold) {
     Preconditions.checkArgument(value.doubleValue() >= threshold.doubleValue(), "Expecting %s >= %d but found %s", param, threshold, value);
   }
-  
+
   protected void checkPositive(String param, Number value) {
     checkGreater(param, value, 0);
   }

--- a/core/src/main/java/org/apache/mahout/clustering/lda/cvb/CachingCVB0Mapper.java
+++ b/core/src/main/java/org/apache/mahout/clustering/lda/cvb/CachingCVB0Mapper.java
@@ -56,6 +56,7 @@ import java.util.Random;
 public class CachingCVB0Mapper
     extends Mapper<IntWritable, VectorWritable, IntWritable, VectorWritable> {
   private static final Logger log = LoggerFactory.getLogger(CachingCVB0Mapper.class);
+  protected CVBConfig config;
   protected ModelTrainer modelTrainer;
   protected int maxIters;
   protected int numTopics;
@@ -66,7 +67,7 @@ public class CachingCVB0Mapper
   protected void setup(Context context) throws IOException, InterruptedException {
     log.info("Retrieving configuration");
     Configuration conf = context.getConfiguration();
-    CVBConfig config = new CVBConfig().read(conf);
+    config = new CVBConfig().read(conf);
     float eta = config.getEta();
     float alpha = config.getAlpha();
     long seed = config.getRandomSeed();

--- a/core/src/main/java/org/apache/mahout/clustering/lda/cvb/InMemoryCollapsedVariationalBayes0.java
+++ b/core/src/main/java/org/apache/mahout/clustering/lda/cvb/InMemoryCollapsedVariationalBayes0.java
@@ -159,7 +159,7 @@ public class InMemoryCollapsedVariationalBayes0 extends AbstractJob {
 
   private void inferDocuments(double convergence, int maxIter, boolean recalculate) {
     for(int docId = 0; docId < corpusWeights.numRows() ; docId++) {
-      Vector inferredDocument = topicModel.infer(corpusWeights.viewRow(docId),
+      Vector inferredDocument = topicModel.expectedTermCounts(corpusWeights.viewRow(docId),
           docTopicCounts.viewRow(docId));
       // do what now?
     }

--- a/core/src/main/java/org/apache/mahout/clustering/lda/cvb/TopicModel.java
+++ b/core/src/main/java/org/apache/mahout/clustering/lda/cvb/TopicModel.java
@@ -308,15 +308,15 @@ public class TopicModel implements Configurable, Iterable<MatrixSlice> {
     double perplexity = Double.MAX_VALUE;
     double relPerplexityDiff = Double.MAX_VALUE;
     int iter = 1;
-    for (; iter <= maxIters || (iter > 1 && relPerplexityDiff < minRelPerplexityDiff); ++iter) {
+    for (; iter <= maxIters && relPerplexityDiff > minRelPerplexityDiff; ++iter) {
       oldPerplexity = perplexity;
       perplexity = perplexity(original, docTopic);
       trainDocTopicModel(original, docTopic, new SparseRowMatrix(numTopics, numTerms));
       if (oldPerplexity < perplexity) {
         log.warn("Document inference lead to increasing perplexity after {} iterations", iter);
-      } else {
-        relPerplexityDiff = (oldPerplexity - perplexity) / oldPerplexity;
+        break;
       }
+      relPerplexityDiff = (oldPerplexity - perplexity) / oldPerplexity;
     }
     log.debug("Relative perplexity difference of {} achieved after {} iterations", relPerplexityDiff, iter);
     return docTopic;


### PR DESCRIPTION
The infer methods iteratively call trainDocTopicModel while keeping track of relative document perplexity difference between iterations. This simplifies iteration till convergence.

Also:
- Updates CVB0DocInferenceMapper to use infer method.
- More cleanup of CVBConfig and CVB0Driver, including additional params to support use of infer method.
