### PR TITLE
Add $HADOOP_HOME/hadoop-core-*.jar to the *beginning* of the classpath,

### DIFF
--- a/bin/mahout
+++ b/bin/mahout
@@ -165,8 +165,8 @@ for f in $MAHOUT_HOME/examples/target/dependency/*.jar; do
 done
 
 # make sure that HADOOP_HOME's hadoop-core jar is first on classpath, to avoid version mismatches
-for f in $HADOOP_HOME/hadoop-core-*.jar; do
-  CLASSPATH=$f:${CLASSPATH};
+for f in "$HADOOP_HOME"/hadoop-core-*.jar; do
+  CLASSPATH="$f:$CLASSPATH";
 done
 
 # default driver class

--- a/bin/mahout
+++ b/bin/mahout
@@ -164,6 +164,11 @@ for f in $MAHOUT_HOME/examples/target/dependency/*.jar; do
   CLASSPATH=${CLASSPATH}:$f;
 done
 
+# make sure that HADOOP_HOME's hadoop-core jar is first on classpath, to avoid version mismatches
+for f in $HADOOP_HOME/hadoop-core-*.jar; do
+  CLASSPATH=$f:${CLASSPATH};
+done
+
 # default driver class
 CLASS=org.apache.mahout.driver.MahoutDriver
 


### PR DESCRIPTION
to make sure that it wins the JarHell battle, in particular to make
sure that "mahout console" works if there is a version mismatch
