### PR TITLE
Allow prior truncation

### DIFF
--- a/core/src/main/java/org/apache/mahout/clustering/lda/cvb/CVBConfig.java
+++ b/core/src/main/java/org/apache/mahout/clustering/lda/cvb/CVBConfig.java
@@ -365,6 +365,7 @@ public class CVBConfig {
   public void check() {
     checkPositive(NUM_TOPICS_PARAM, numTopics);
     checkPositive(NUM_TERMS_PARAM, numTerms);
+    checkGreater(NUM_TERMS_PARAM, numTerms, numTopics);
     checkPositive(DOC_TOPIC_SMOOTHING_PARAM, alpha);
     checkPositive(TERM_TOPIC_SMOOTHING_PARAM, eta);
     checkPositive(RANDOM_SEED_PARAM, randomSeed);
@@ -378,11 +379,13 @@ public class CVBConfig {
   }
 
   protected void checkGreater(String param, Number value, Number threshold) {
-    Preconditions.checkArgument(value.doubleValue() > threshold.doubleValue(), "Expecting %s > %d but found %s", param, threshold, value);
+    Preconditions.checkArgument(value.doubleValue() > threshold.doubleValue(),
+                                "Expecting %s > %d but found %s", param, threshold, value);
   }
 
   protected void checkGreaterOrEqual(String param, Number value, Number threshold) {
-    Preconditions.checkArgument(value.doubleValue() >= threshold.doubleValue(), "Expecting %s >= %d but found %s", param, threshold, value);
+    Preconditions.checkArgument(value.doubleValue() >= threshold.doubleValue(),
+                                "Expecting %s >= %d but found %s", param, threshold, value);
   }
 
   protected void checkPositive(String param, Number value) {

--- a/core/src/main/java/org/apache/mahout/clustering/lda/cvb/PriorTrainingReducer.java
+++ b/core/src/main/java/org/apache/mahout/clustering/lda/cvb/PriorTrainingReducer.java
@@ -54,6 +54,7 @@ public class PriorTrainingReducer extends MapReduceBase
   private ModelTrainer modelTrainer;
   private int maxIters;
   private int numTopics;
+  private int numTerms;
   private boolean onlyLabeledDocs;
   private MultipleOutputs multipleOutputs;
   private Reporter reporter;
@@ -79,7 +80,7 @@ public class PriorTrainingReducer extends MapReduceBase
       double eta = c.getEta();
       double alpha = c.getAlpha();
       numTopics = c.getNumTopics();
-      int numTerms = c.getNumTerms();
+      numTerms = c.getNumTerms();
       int numUpdateThreads = c.getNumUpdateThreads();
       int numTrainThreads = c.getNumTrainThreads();
       maxIters = c.getMaxItersPerDoc();
@@ -127,10 +128,15 @@ public class PriorTrainingReducer extends MapReduceBase
     Vector document = null;
     while(vectors.hasNext()) {
       VectorWritable v = vectors.next();
-      if(v.get().size() == numTopics) {
-        topicVector = v.get();
-      } else {
+      /*
+       *  NOTE: we are susceptible to the pathological case of numTerms == numTopics (which should
+       *  never happen, as that would generate a horrible topic model), because we identify which
+       *  vector is the "prior" and which is the document by document.size() == numTerms
+       */
+      if(v.get().size() == numTerms) {
         document = v.get();
+      } else {
+        topicVector = v.get();
       }
     }
     if(document == null) {

--- a/core/src/main/java/org/apache/mahout/clustering/lda/cvb/TopicModel.java
+++ b/core/src/main/java/org/apache/mahout/clustering/lda/cvb/TopicModel.java
@@ -374,6 +374,8 @@ public class TopicModel implements Configurable, Iterable<MatrixSlice> {
       double topicSum = topicSums.get(x);
       // get p(topic x | term a) distribution to update
       Vector termTopicRow = termTopicDist.viewRow(x);
+      // cache factor which is the same for all terms, for this fixed topic.
+      double topicMult = (topicSum + eta * numTerms) / (topicWeight + alpha);
 
       // for each term a in document i with non-zero weight
       Iterator<Vector.Element> it = document.iterateNonZero();
@@ -382,7 +384,7 @@ public class TopicModel implements Configurable, Iterable<MatrixSlice> {
         int termIndex = e.index();
 
         // calc un-normalized p(topic x | term a, document i)
-        double termTopicLikelihood = (topicTermRow.get(termIndex) + eta) * (topicWeight + alpha) / (topicSum + eta * numTerms);
+        double termTopicLikelihood = (topicTermRow.get(termIndex) + eta) * topicMult;
         termTopicRow.set(termIndex, termTopicLikelihood);
       }
     }

--- a/core/src/main/java/org/apache/mahout/clustering/lda/cvb/TopicModel.java
+++ b/core/src/main/java/org/apache/mahout/clustering/lda/cvb/TopicModel.java
@@ -375,7 +375,7 @@ public class TopicModel implements Configurable, Iterable<MatrixSlice> {
       // get p(topic x | term a) distribution to update
       Vector termTopicRow = termTopicDist.viewRow(x);
       // cache factor which is the same for all terms, for this fixed topic.
-      double topicMult = (topicSum + eta * numTerms) / (topicWeight + alpha);
+      double topicMult = (topicWeight + alpha) / (topicSum + eta * numTerms);
 
       // for each term a in document i with non-zero weight
       Iterator<Vector.Element> it = document.iterateNonZero();

--- a/core/src/test/java/org/apache/mahout/clustering/lda/cvb/TestCVBModelTrainer.java
+++ b/core/src/test/java/org/apache/mahout/clustering/lda/cvb/TestCVBModelTrainer.java
@@ -198,7 +198,9 @@ public class TestCVBModelTrainer extends MahoutTestCase {
     Path topicModelStateTempPath = getTestTempDirPath("topicTemp");
     Path outputPath = new Path(getTestTempDirPath(), "finalOutput");
     int numIterations = 10;
-    CVBConfig cvbConfig = new CVBConfig().setAlpha(ALPHA).setEta(ETA).setNumTopics(numGeneratingTopics)
+    int numTopics = numGeneratingTopics - 2;
+    CVBConfig cvbConfig = new CVBConfig().setAlpha(ALPHA).setEta(ETA)
+          .setNumTopics(numTopics)
           .setBackfillPerplexity(false).setConvergenceDelta(0).setDictionaryPath(null)
           .setModelTempPath(topicModelStateTempPath).setTestFraction(0.2f).setNumTerms(numTerms)
           .setMaxIterations(numIterations).setInputPath(sampleCorpusPath).setNumTrainThreads(1)
@@ -213,7 +215,7 @@ public class TestCVBModelTrainer extends MahoutTestCase {
       modelParts.add(fileStatus.getPath());
     }
     Pair<Matrix, Vector> model = TopicModel.loadModel(conf, modelParts.toArray(new Path[0]));
-    for(int topic = 0; topic < numGeneratingTopics; topic++) {
+    for(int topic = 0; topic < numTopics; topic++) {
       Vector topicDist = model.getFirst().viewRow(topic);
       int term = mostProminentFeature(topicDist);
       int expectedTopicForTerm = expectedTopicForTerm(matrix, term);


### PR DESCRIPTION
Branch to allow LLDA priors to have higher dimensionality than the requested number of topics - they are simply truncated.
